### PR TITLE
feat: vendor has custom_packaging_tutorial_url field

### DIFF
--- a/addons/blink/__manifest__.py
+++ b/addons/blink/__manifest__.py
@@ -26,7 +26,8 @@ Preferences
         'views/picking.xml',
         'views/location.xml',
         'views/purchase.xml',
-        'views/user.xml'
+        'views/user.xml',
+        'views/partner.xml'
     ],
     'demo': [],
     'installable': True,

--- a/addons/blink/models/__init__.py
+++ b/addons/blink/models/__init__.py
@@ -6,4 +6,5 @@ from . import stock
 from . import purchase
 from . import package
 from . import user
+from . import partner
 

--- a/addons/blink/models/partner.py
+++ b/addons/blink/models/partner.py
@@ -1,0 +1,7 @@
+from odoo import api, fields, models
+
+
+class Partner(models.Model):
+    _inherit = 'res.partner'
+
+    custom_packaging_tutorial_url = fields.Char(string='Packaging tutorial')

--- a/addons/blink/models/stock.py
+++ b/addons/blink/models/stock.py
@@ -28,7 +28,7 @@ class StockPicking(models.Model):
     @api.depends('move_line_ids')
     def set_tutorial_url(self):
         for rec in self:
-            pass
+            rec.tutorial_url = None
             # To do
             # tutorial_url must be dependent on products' vendor's custom_packaging_tutorial_url.
             # As stock.picking as default is not related to vendor, since sale lines can be collection of products

--- a/addons/blink/models/stock.py
+++ b/addons/blink/models/stock.py
@@ -18,11 +18,28 @@ class StockPicking(models.Model):
     first_order = fields.Boolean(related="sale_id.first_order", string='First Order')
     external_delivery_id = fields.Char(related="sale_id.external_delivery_id", string="External id")
     delivery_url = fields.Char(string="Delivery label", compute="set_delivery_url")
+    tutorial_url = fields.Char(string="Tutorial url", compute="set_tutorial_url")
 
     @api.depends('external_delivery_id')
     def set_delivery_url(self):
         for rec in self:
             rec.delivery_url = get_delivery_url(rec.external_delivery_id)
+
+    @api.depends('move_line_ids')
+    def set_tutorial_url(self):
+        for rec in self:
+            pass
+            # To do
+            # tutorial_url must be dependent on products' vendor's custom_packaging_tutorial_url.
+            # As stock.picking as default is not related to vendor, since sale lines can be collection of products
+            #  from multiple vendors
+            # So, the solution is to get vendor, from the move_line
+
+            # This doesn't work
+            # if rec.move_line_ids:
+            #     rec.tutorial_url = rec.move_line_ids[0].owner_id.custom_packaging_tutorial_url
+            # else:
+            #     rec.tutorial_url = None
 
     def action_sync_packages(self):
         stock_picking = super(StockPicking, self)

--- a/addons/blink/views/partner.xml
+++ b/addons/blink/views/partner.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_res_partner_form_inherit" model="ir.ui.view">
+            <field name="name">res.partner.form</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+                <field name='website' position="after">
+                        <field name="custom_packaging_tutorial_url" widget="url"/>
+                </field>
+            </field>
+        </record>
+    </data>
+
+
+</odoo>

--- a/addons/blink/views/picking.xml
+++ b/addons/blink/views/picking.xml
@@ -12,6 +12,7 @@
                 <field name="date_done" position="after">
                 		<field name="deliv_label" widget="url"/>
                         <field name="delivery_url" widget="url"/>
+                        <field name="tutorial_url" widget="url"/>
                 		<field name="first_order"/>
             	</field>
             </field>


### PR DESCRIPTION
Feature is not complete. But safe to merge. PR would add tutorial_url field for Vendors. But the link is not shown in Pack process.